### PR TITLE
Actualizar estilo del index y avatares modernos

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -6,22 +6,23 @@
   <title>TrascendencIA Sindical</title>
   <style>
     :root {
-      --bg-base: #020b1f;
-      --bg-gradient: radial-gradient(circle at 10% 10%, #0d4a76 0%, transparent 55%),
-                      radial-gradient(circle at 80% 0%, #0c2f52 0%, transparent 45%),
-                      radial-gradient(circle at 50% 90%, #07243f 0%, transparent 60%),
-                      #020b1f;
-      --fg: #d9e7ff;
-      --panel: rgba(6, 22, 41, 0.78);
-      --panel-border: rgba(0, 255, 255, 0.12);
-      --panel-glow: 0 0 0 1px rgba(0, 191, 255, 0.15), 0 10px 40px rgba(5, 15, 35, 0.9);
-      --header-gradient: linear-gradient(135deg, rgba(0, 173, 255, 0.7), rgba(0, 255, 204, 0.4));
-      --bot-bg: rgba(11, 33, 58, 0.85);
-      --user-bg: linear-gradient(135deg, #00d4ff, #007bff);
-      --input-bg: rgba(5, 18, 33, 0.85);
-      --border: rgba(0, 245, 255, 0.15);
-      --accent: #00e0ff;
-      --accent-soft: rgba(0, 224, 255, 0.16);
+      --bg-base: #0a0f1d;
+      --bg-gradient: radial-gradient(60vmax 60vmax at 50% 40%, rgba(96, 165, 250, .18), transparent 60%),
+                      linear-gradient(180deg, #071122, #0a0f1d);
+      --fg: #e5f2ff;
+      --panel: rgba(9, 14, 26, 0.7);
+      --panel-border: rgba(91, 215, 242, 0.25);
+      --panel-glow: 0 0 0 1px rgba(91, 215, 242, 0.22), 0 20px 45px rgba(3, 10, 20, 0.7);
+      --header-gradient: linear-gradient(90deg, rgba(91, 215, 242, .75), rgba(96, 165, 250, .55));
+      --bot-bg: rgba(11, 28, 50, 0.92);
+      --user-bg: linear-gradient(135deg, rgba(96, 165, 250, 0.95), rgba(91, 215, 242, 0.9));
+      --input-bg: rgba(5, 14, 26, 0.85);
+      --border: rgba(91, 215, 242, 0.2);
+      --accent: #5bd7f2;
+      --accent-soft: rgba(91, 215, 242, 0.2);
+      --grid-line: rgba(96, 165, 250, 0.1);
+      --avatar-user: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='64' height='64' viewBox='0 0 64 64'%3E%3Cdefs%3E%3ClinearGradient id='g' x1='0' x2='1' y1='0' y2='1'%3E%3Cstop stop-color='%2360a5fa'/%3E%3Cstop offset='1' stop-color='%235bd7f2'/%3E%3C/linearGradient%3E%3C/defs%3E%3Crect width='64' height='64' rx='20' fill='url(%23g)'/%3E%3Cpath fill='white' fill-opacity='0.9' d='M32 36c6.3 0 11.4-5.1 11.4-11.4S38.3 13.2 32 13.2 20.6 18.3 20.6 24.6 25.7 36 32 36zm0 4.8c-8.6 0-16.3 4.3-20.6 10.9-.5.8 0 2 1 2h39.2c1 0 1.6-1.2 1-2-4.3-6.6-12-10.9-20.6-10.9z'/%3E%3C/svg%3E");
+      --avatar-bot: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='64' height='64' viewBox='0 0 64 64'%3E%3Cdefs%3E%3ClinearGradient id='g' x1='0' x2='1' y1='0' y2='1'%3E%3Cstop stop-color='%230f172a'/%3E%3Cstop offset='1' stop-color='%23254869'/%3E%3C/linearGradient%3E%3C/defs%3E%3Crect width='64' height='64' rx='20' fill='url(%23g)'/%3E%3Cpath fill='%235bd7f2' d='M22 22h20c3.3 0 6 2.7 6 6v12c0 3.3-2.7 6-6 6H22c-3.3 0-6-2.7-6-6V28c0-3.3 2.7-6 6-6z'/%3E%3Ccircle cx='26' cy='34' r='3' fill='%23ffffff'/%3E%3Ccircle cx='38' cy='34' r='3' fill='%23ffffff'/%3E%3Cpath d='M26 18l2-6h8l2 6' stroke='%235bd7f2' stroke-width='2' stroke-linecap='round'/%3E%3C/svg%3E");
       --font-main: 'Segoe UI', 'Roboto', 'Helvetica Neue', sans-serif;
     }
     * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -34,6 +35,17 @@
       align-items: center;
       justify-content: center;
       padding: 2.5rem 1.5rem;
+      overflow: hidden;
+    }
+    body::before {
+      content: "";
+      position: fixed;
+      inset: 0;
+      pointer-events: none;
+      opacity: 0.25;
+      background-image: linear-gradient(to right, var(--grid-line) 1px, transparent 1px),
+                        linear-gradient(to bottom, var(--grid-line) 1px, transparent 1px);
+      background-size: 48px 48px;
     }
     #app {
       width: min(960px, 100%);
@@ -54,7 +66,7 @@
       inset: 0;
       pointer-events: none;
       border-radius: inherit;
-      border: 1px solid rgba(0, 221, 255, 0.07);
+      border: 1px solid rgba(91, 215, 242, 0.12);
       mix-blend-mode: screen;
     }
 
@@ -62,7 +74,8 @@
     header {
       padding: 1.25rem 1.75rem 1rem;
       border-bottom: 1px solid var(--accent-soft);
-      background: linear-gradient(180deg, rgba(5, 22, 41, 0.72), rgba(5, 22, 41, 0.35));
+      background: linear-gradient(180deg, rgba(9, 14, 26, 0.85), rgba(9, 14, 26, 0.55));
+      backdrop-filter: blur(10px);
       display: flex;
       justify-content: space-between;
       align-items: center;
@@ -95,11 +108,11 @@
     }
     .title::before {
       content: "";
-      width: 10px;
-      height: 10px;
-      border-radius: 50%;
-      background: var(--accent);
-      box-shadow: 0 0 12px rgba(0, 224, 255, 0.85);
+      width: 12px;
+      height: 12px;
+      border-radius: 6px;
+      background: linear-gradient(135deg, rgba(96, 165, 250, 0.9), rgba(91, 215, 242, 0.8));
+      box-shadow: 0 0 12px rgba(91, 215, 242, 0.65);
     }
 
     /* Botón Volver (glassmórfico) */
@@ -109,26 +122,26 @@
       gap:.4rem;
       padding:.55rem 1.1rem;
       border-radius:999px;
-      border:1px solid rgba(0,224,255,.25);
-      background:rgba(4,24,43,.6);
+      border:1px solid rgba(91,215,242,.3);
+      background:rgba(9,14,26,.6);
       color:var(--accent);
       text-decoration:none;
       font-size:.9rem;
       letter-spacing:.04em;
       transition:transform .2s ease, box-shadow .2s ease, border-color .2s ease;
-      box-shadow:0 10px 25px rgba(0,174,255,.18);
+      box-shadow:0 12px 28px rgba(7, 19, 34, .55);
     }
     .back-button::before{ content:'←'; font-size:1rem; }
     .back-button:hover{
       transform:translateY(-1px);
-      border-color:rgba(0,224,255,.45);
-      box-shadow:0 14px 28px rgba(0,224,255,.3);
+      border-color:rgba(91,215,242,.6);
+      box-shadow:0 18px 32px rgba(91,215,242,.3);
     }
     .back-button:active{ transform:translateY(0); }
 
     .subtitle {
       font-size: 0.9rem;
-      opacity: 0.7;
+      opacity: 0.8;
       letter-spacing: 0.18em;
       text-transform: uppercase;
     }
@@ -156,12 +169,18 @@
     }
     .message.user { margin-left: auto; flex-direction: row-reverse; }
     .avatar {
-      width: 32px;
-      height: 32px;
-      border-radius: 50%;
+      width: 36px;
+      height: 36px;
+      border-radius: 14px;
       margin: 0 0.5rem;
       flex-shrink: 0;
+      background-size: cover;
+      background-position: center;
+      border: 1px solid rgba(91, 215, 242, 0.35);
+      box-shadow: 0 10px 18px rgba(2, 10, 20, 0.5);
     }
+    .avatar.bot { background-image: var(--avatar-bot); }
+    .avatar.user { background-image: var(--avatar-user); }
     .bubble {
       position: relative;
       padding: 0.9rem 1.2rem;
@@ -174,14 +193,14 @@
       background: var(--user-bg);
       color: #f5fbff;
       border-bottom-right-radius: 0.25rem;
-      border-color: rgba(0, 230, 255, 0.25);
-      box-shadow: 0 18px 30px rgba(0, 173, 255, 0.25);
+      border-color: rgba(91, 215, 242, 0.3);
+      box-shadow: 0 18px 30px rgba(91, 215, 242, 0.25);
     }
     .message.bot .bubble {
       background: var(--bot-bg);
       color: var(--fg);
       border-bottom-left-radius: 0.25rem;
-      border-color: rgba(0, 224, 255, 0.08);
+      border-color: rgba(91, 215, 242, 0.18);
     }
     .message.user .bubble::after {
       content: "";
@@ -211,9 +230,9 @@
     #texto {
       flex: 1;
       padding: 0.85rem 1rem;
-      background: rgba(7, 29, 54, 0.7);
+      background: rgba(7, 18, 34, 0.7);
       color: var(--fg);
-      border: 1px solid rgba(0, 210, 255, 0.2);
+      border: 1px solid rgba(91, 215, 242, 0.24);
       outline: none;
       font-size: 1rem;
       border-radius: 999px;
@@ -228,17 +247,17 @@
       font-size: 1rem;
       border-radius: 999px;
       transition: transform .2s, box-shadow .2s, filter .2s;
-      box-shadow: 0 12px 25px rgba(0, 174, 255, 0.35);
+      box-shadow: 0 12px 25px rgba(91, 215, 242, 0.35);
     }
     #enviar:hover:not(:disabled) {
       filter: brightness(1.1);
       transform: translateY(-1px);
-      box-shadow: 0 18px 30px rgba(0, 224, 255, 0.45);
+      box-shadow: 0 18px 30px rgba(91, 215, 242, 0.45);
     }
     #enviar:disabled { opacity: 0.5; cursor: not-allowed; }
     #texto:focus {
-      border-color: rgba(0, 224, 255, 0.45);
-      box-shadow: 0 0 0 3px rgba(0, 224, 255, 0.12);
+      border-color: rgba(91, 215, 242, 0.55);
+      box-shadow: 0 0 0 3px rgba(91, 215, 242, 0.12);
     }
 
     /* Responsive */
@@ -282,10 +301,9 @@
     function appendMessage(role, text) {
       const msg = document.createElement('div');
       msg.className = `message ${role}`;
-      const avatar = document.createElement('img');
-      avatar.className = 'avatar';
-      avatar.src = role === 'bot' ? '/static/bot-avatar.png' : '';
-      avatar.alt = role === 'bot' ? 'Asistente' : '';
+      const avatar = document.createElement('div');
+      avatar.className = `avatar ${role}`;
+      avatar.setAttribute('aria-hidden', 'true');
       const bubble = document.createElement('div');
       bubble.className = 'bubble';
       bubble.textContent = text;


### PR DESCRIPTION
### Motivation
- Actualizar la interfaz del `index` para acercarla al estilo SInOS con aspecto glassmórfico y fondo de rejilla.
- Sustituir los avatares por iconos genéricos modernos embebidos para evitar dependencias externas y dar una apariencia coherente.
- Afinar la presentación de chat, cabecera e inputs para una experiencia visual más limpia y responsiva.

### Description
- Rework de `static/index.html` para cambiar variables CSS, paleta, fondo en rejilla y sombras, y añadir reglas de `backdrop-filter` y tamaños responsivos.
- Introducción de `--avatar-user` y `--avatar-bot` como `data:` SVG en variables CSS y cambio de elemento avatar de `<img>` a elementos `div.avatar` estilizados.
- Ajustes de estilos en botones, burbujas de chat y entrada de texto para alinear colores, bordes y efectos de foco con la nueva paleta.
- Modificación del constructor de mensajes en `appendMessage` para crear el avatar como `div` con la clase correspondiente y marcarlo `aria-hidden`.

### Testing
- Se generó una captura visual automatizada de la página con Playwright y se guardó en `artifacts/index-style.png`.
- Intentar iniciar el servidor con `uvicorn main:app` falló por un `ModuleNotFoundError` en `langchain.text_splitter`, impidiendo pruebas de integración más profundas.
- No se ejecutaron tests unitarios automatizados en esta PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955223395a88328847dea625d85a5c8)